### PR TITLE
Handle formatting numbers larger than 100k 

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "drag-drop": "^4.2.0",
     "preact": "^8.2.7",
     "preact-compat": "^3.18.4",
+    "numeral": "^2.0.6",
     "recharts": "^1.4.2",
     "statgrab": "^1.2.0",
     "yaafloop": "^1.1.0"

--- a/source/views/ExtensionInsights.view.js
+++ b/source/views/ExtensionInsights.view.js
@@ -1,3 +1,4 @@
+const numeral = require("numeral");
 import Preact from "preact"
 import * as Recharts from "recharts"
 // TODO: Consider precharts vs recharts
@@ -257,10 +258,11 @@ function toPercentage(value) {
 
 function toCount(value) {
     if(value < 1000) {
-        return value
+        return String(value)
+    } else {
+        // value like "1.00k, 3.29m, 5.67b"
+        return numeral(value).format("0.00a")
     }
-
-    return Math.round(value / 1000) + "k"
 }
 
 // Colors were generated and selected from:


### PR DESCRIPTION
## Purpose
Currently, numbers larger than 999,999 are formatted weird-- instead of being 1M, they're 1000K

## What this does
Using an existing library, formats numbers > 1000 with `k`, `m`, `b`, `t`, etc.

## Screenshot
![image](https://user-images.githubusercontent.com/2659644/52987956-35201100-33b2-11e9-80d8-8ff72d42172b.png)
